### PR TITLE
Fix UI layout and add letter workflow

### DIFF
--- a/Scenes/main.tscn
+++ b/Scenes/main.tscn
@@ -14,14 +14,17 @@ follow_viewport_enabled = true
 
 [node name="TextureRect" type="TextureRect" parent="CanvasLayer"]
 anchors_preset = 15
+anchor_left = 0.0
+anchor_top = 0.0
 anchor_right = 1.0
 anchor_bottom = 1.0
-offset_left = 28.0
-offset_right = 1314.0
-offset_bottom = 706.0
+offset_left = 0.0
+offset_top = 0.0
+offset_right = 0.0
+offset_bottom = 0.0
 grow_horizontal = 2
 grow_vertical = 2
-scale = Vector2(0.55, 0.55)
+scale = Vector2(1, 1)
 texture = ExtResource("1_jjgbg")
 stretch_mode = 5
 
@@ -58,45 +61,59 @@ offset_left = -181.819
 offset_top = -236.364
 offset_right = 370.181
 offset_bottom = 261.636
+visible = false
 texture = ExtResource("4_21xkr")
 
 [node name="PanelContainer" type="PanelContainer" parent="CanvasLayer"]
+visible = false
 anchors_preset = 12
+anchor_left = 0.0
 anchor_top = 1.0
 anchor_right = 1.0
 anchor_bottom = 1.0
 offset_left = 145.0
-offset_top = -180.0
-offset_right = 187.0
-offset_bottom = 326.0
+offset_top = -250.0
+offset_right = -145.0
+offset_bottom = 0.0
 grow_horizontal = 2
 grow_vertical = 0
-scale = Vector2(0.85, 0.3)
+scale = Vector2(1, 1)
 
 [node name="TextureRect" type="TextureRect" parent="CanvasLayer/PanelContainer"]
 layout_mode = 2
 texture = ExtResource("4_kry3j")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="CanvasLayer/PanelContainer/TextureRect"]
-layout_mode = 0
-offset_left = 44.7059
-offset_top = 60.0
-offset_right = 1274.71
-offset_bottom = 460.0
+layout_mode = 2
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 20.0
+offset_top = 20.0
+offset_right = -20.0
+offset_bottom = -20.0
 alignment = 1
 
 [node name="RichTextLabel" type="RichTextLabel" parent="CanvasLayer/PanelContainer/TextureRect/VBoxContainer"]
 layout_mode = 2
-text = "TEST 1"
+text = "Prompt"
 
 [node name="RichTextLabel2" type="RichTextLabel" parent="CanvasLayer/PanelContainer/TextureRect/VBoxContainer"]
 layout_mode = 2
-text = "Test 2"
+text = "Option A"
 
 [node name="RichTextLabel3" type="RichTextLabel" parent="CanvasLayer/PanelContainer/TextureRect/VBoxContainer"]
 layout_mode = 2
-text = "Test 3
-"
+text = "Option B"
+
+[node name="RichTextLabel4" type="RichTextLabel" parent="CanvasLayer/PanelContainer/TextureRect/VBoxContainer"]
+layout_mode = 2
+text = "Option C"
+
+[node name="OptionInput" type="LineEdit" parent="CanvasLayer/PanelContainer/TextureRect/VBoxContainer"]
+layout_mode = 2
+placeholder_text = "Escribe A, B o C y pulsa Enter"
 
 [node name="Camera2D" type="Camera2D" parent="."]
 position = Vector2(700, 400)

--- a/Scripts/game_manager.gd
+++ b/Scripts/game_manager.gd
@@ -1,15 +1,56 @@
 # GameManager.gd
 extends Node
 
-func _ready():
-	# Connect all existing Clickable nodes using a Callable
-	for clickable in get_tree().get_nodes_in_group("Clickable"):
-		clickable.connect("clicked", self._on_clickable_clicked)
+var unread_letters: Array = []
 
-# If you add clickables at runtime, use this helper too
+func _ready():
+        for clickable in get_tree().get_nodes_in_group("Clickable"):
+                clickable.clicked.connect(self._on_clickable_clicked)
+        LetterManager.letter_received.connect(self._on_letter_received)
+        LetterManager.composition_prompt.connect(self._on_composition_prompt)
+        LetterManager.letter_sent.connect(self._on_letter_sent)
+        $CanvasLayer/PanelContainer/TextureRect/VBoxContainer/OptionInput.text_submitted.connect(self._on_OptionInput_text_submitted)
+
 func connect_clickable(clickable):
-	clickable.connect("clicked", self._on_clickable_clicked)
+        clickable.clicked.connect(self._on_clickable_clicked)
 
 func _on_clickable_clicked(node):
-	# Called when any ColorRect-Clickable emits "clicked"
-	print("Clicked node: %s" % node.name)
+        if node.name == "LetterClicker":
+                _show_next_letter()
+        elif node.name == "ComputerClicker":
+                LetterManager.start_letter("COM001")
+        print("Clicked node: %s" % node.name)
+
+func _on_letter_received(text):
+        unread_letters.append(text)
+        $CanvasLayer/TextureRect/LetterClicker/LetterAlert.visible = true
+
+func _on_letter_sent(text):
+        $CanvasLayer/PanelContainer.visible = false
+
+func _on_composition_prompt(prompt, options):
+        var panel = $CanvasLayer/PanelContainer
+        panel.visible = true
+        panel.get_node("TextureRect/VBoxContainer/RichTextLabel").text = prompt
+        panel.get_node("TextureRect/VBoxContainer/OptionInput").text = ""
+        var keys = options.keys()
+        keys.sort()
+        var labels = [
+                panel.get_node("TextureRect/VBoxContainer/RichTextLabel2"),
+                panel.get_node("TextureRect/VBoxContainer/RichTextLabel3"),
+                panel.get_node("TextureRect/VBoxContainer/RichTextLabel4")
+        ]
+        for i in range(min(labels.size(), options.size())):
+                labels[i].text = "%s: %s" % [keys[i], options[keys[i]]]
+
+func _show_next_letter():
+        if unread_letters.is_empty():
+                return
+        var letter = unread_letters.pop_front()
+        print("READ LETTER:\n" + letter)
+        if unread_letters.is_empty():
+                $CanvasLayer/TextureRect/LetterClicker/LetterAlert.visible = false
+
+func _on_OptionInput_text_submitted(new_text):
+        LetterManager.choose_option(new_text.strip_edges().to_upper())
+        $CanvasLayer/PanelContainer/TextureRect/VBoxContainer/OptionInput.text = ""

--- a/Scripts/letter_manager.gd
+++ b/Scripts/letter_manager.gd
@@ -20,10 +20,11 @@ var conversation: Array = []  # cada entrada: { type: "sent"/"received", text: S
 
 
 func _ready() -> void:
-	print("[Letter Manager] Loaded")
-	comp_data   = _load_json("res://Letters/composition.json")
-	letter_meta = _load_json("res://Letters/letter.json")
-	resp_data   = _load_json("res://Letters/responses.json")
+        print("[Letter Manager] Loaded")
+        comp_data   = _load_json("res://Letters/composition.json")
+        letter_meta = _load_json("res://Letters/letter.json")
+        resp_data   = _load_json("res://Letters/responses.json")
+        _deliver_initial_letter()
 
 
 func _load_json(path: String) -> Dictionary:
@@ -93,7 +94,7 @@ func _schedule_response() -> void:
 
 
 func _on_response_timeout() -> void:
-	print("[Letter Manager] On Response Timeout")
+        print("[Letter Manager] On Response Timeout")
 	# Construïm la clau del camí: "A_B_C"
 	var key = ""
 	for i in range(choice_path.size()):
@@ -112,4 +113,13 @@ func _on_response_timeout() -> void:
 		"text": reply_text,
 		"timestamp": Time.get_unix_time_from_system() as int
 	})
-	emit_signal("letter_received", reply_text)
+        emit_signal("letter_received", reply_text)
+
+func _deliver_initial_letter() -> void:
+        var text = "Benvolguda, aquesta és la primera carta de Ku'umi."
+        conversation.append({
+                "type": "received",
+                "text": text,
+                "timestamp": Time.get_unix_time_from_system() as int
+        })
+        emit_signal("letter_received", text)


### PR DESCRIPTION
## Summary
- resize background and writing panel properly
- hide LetterAlert until a letter arrives
- add prompt/option labels and input field
- deliver an initial letter from LetterManager on startup
- manage letter UI flow from GameManager

------
https://chatgpt.com/codex/tasks/task_e_6879f977d7b483258b22ccdf2c8a8424